### PR TITLE
Add -please|plz parameter

### DIFF
--- a/sudo.ps1
+++ b/sudo.ps1
@@ -49,7 +49,12 @@ if(!(is_admin)) {
 	exit 1
 }
 
-$a = serialize $args $true
+$a = if ($args[0] -eq '-please' -or $args[0] -eq '-plz') {
+	Get-History -Count 1 | select -ExpandProperty CommandLine
+} else {
+	serialize $args $true
+}
+
 $wd = serialize (convert-path $pwd) # convert-path in case pwd is a PSDrive
 
 $savetitle = $host.ui.rawui.windowtitle


### PR DESCRIPTION
Add switch so that the script will re-do previous command with elevated privileges. For convenience.
```
psutils master $ mkdir 'C:\Program Files\foo'
mkdir : Access to the path 'foo' is denied.
At line:1 char:1
+ mkdir 'C:\Program Files\foo'
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : PermissionDenied: (C:\Program Files\foo:String) [New-Item], UnauthorizedAccessException
    + FullyQualifiedErrorId : CreateDirectoryUnauthorizedAccessError,Microsoft.PowerShell.Commands.NewItemCommand


psutils master $ sudo -plz


    Directory: C:\Program Files


Mode                LastWriteTime         Length Name
----                -------------         ------ ----
d-----       23.03.2017     22.44                foo

psutils master $```