### PR TITLE
Fix 22: touch fails when running in strict mode

### DIFF
--- a/getopt.ps1
+++ b/getopt.ps1
@@ -9,6 +9,8 @@
 #    a parameter should end with '='
 # returns @(opts hash, rem_args array, error string)
 function getopt($argv, $shortopts, $longopts) {
+	Set-StrictMode -Off;
+
 	$opts = @{}; $rem = @()
 
 	function err($msg) {

--- a/gitignore.ps1
+++ b/gitignore.ps1
@@ -1,3 +1,5 @@
+Set-StrictMode -Off;
+
 $usage = "usage:
 gitignore arg ..."
 

--- a/ln.ps1
+++ b/ln.ps1
@@ -1,3 +1,5 @@
+Set-StrictMode -Off;
+
 # bodge the ln command
 $usage = "usage: ln [-s] <target> [link_name]"
 

--- a/runat.ps1
+++ b/runat.ps1
@@ -1,3 +1,5 @@
+Set-StrictMode -Off;
+
 $usage = "usage: runat (time) (command)
     
 e.g. runat 2am shutdown -r -f -c ""restart""";

--- a/say.ps1
+++ b/say.ps1
@@ -1,3 +1,5 @@
+Set-StrictMode -Off;
+
 # note: requires getopt.ps1 in the same directory
 # `scoop install say` takes care of this
 . "$psscriptroot\getopt.ps1"

--- a/shasum.ps1
+++ b/shasum.ps1
@@ -1,3 +1,5 @@
+Set-StrictMode -Off;
+
 . "$psscriptroot\getopt.ps1"
 
 function usage {

--- a/shim.ps1
+++ b/shim.ps1
@@ -1,5 +1,7 @@
 param($path, [switch]$help)
 
+Set-StrictMode -Off;
+
 $usage = "usage: shim <path>"
 
 function create_shim($path) {

--- a/sudo.ps1
+++ b/sudo.ps1
@@ -1,3 +1,5 @@
+Set-StrictMode -Off;
+
 if(!$args) { "usage: sudo <cmd...>"; exit 1 }
 
 function is_admin {

--- a/time.ps1
+++ b/time.ps1
@@ -1,3 +1,5 @@
+Set-StrictMode -Off;
+
 # see http://stackoverflow.com/a/3513669/87453
 $cmd, $args = $args
 $args = @($args)

--- a/touch.ps1
+++ b/touch.ps1
@@ -1,3 +1,5 @@
+Set-StrictMode -Off;
+
 $usage = "usage:
 touch [-A [-][[hh]mm]SS] [-acm] [-r file] [-t [[CC]YY]MMDDhhmm[.SS]] file ..."
 

--- a/vimtutor.ps1
+++ b/vimtutor.ps1
@@ -8,6 +8,8 @@
 # work with Scoop in Powershell
 param($xx)
 
+Set-StrictMode -Off;
+
 if(!$xx) { $xx = (get-uiculture).twoLetterISOLanguageName }
 
 $vim = scoop which vim


### PR DESCRIPTION
As discussed in #22 the scripts have been updated to ensure strict mode is off when running. Set-StrictMode only applies to the current and child scopes, and so is automatically reverted on return.