### PR TITLE
Mention the gitignore script in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 psutils
 =======
 
-A collection of command line utilities written in Powershell, proudly ignoring Powershell Verb-Noun naming conventions.
+A collection of command line utilities written in PowerShell, proudly ignoring PowerShell Verb-Noun naming conventions.
 
 These are designed to be installed with [Scoop](http://scoop.sh).
 
+* *gitignore* - Fetches `.gitignore` file templates from [gitignore.io](https://www.gitignore.io/) and writes them to standard output.
 * *ln* - An approximation of the Unix `ln` command.
 * *runat* - A replacement for the `at` command which Microsoft has deprecated and removed in Windows 2012.
-* *say* - An approximation of [`say`](https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man1/say.1.html) from Mac OS X.
+* *say* - An approximation of [`say`](https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man1/say.1.html) from macOS.
 * *shasum* - An approximation of [shasum](http://linux.die.net/man/1/shasum).
 * *sudo* - An approximation of the Unix `sudo` command. Shows a UAC popup window unfortunately.
 * *time* - An approximation of the Unix `time` command.


### PR DESCRIPTION
This documents the presence of `gitignore.ps1` in this repository. I also updated the README to use the official namings for PowerShell and macOS.