### PR TITLE
inherit execution policy

### DIFF
--- a/sudo.ps1
+++ b/sudo.ps1
@@ -3,9 +3,9 @@ Set-StrictMode -Off;
 if(!$args) { "usage: sudo <cmd...>"; exit 1 }
 
 $powershellExe = Get-Process -Id $pid | Select-Object -ExpandProperty Path
-$commandPrefix = ''
+$commandPrefix = "-ExecutionPolicy $(Get-ExecutionPolicy) "
 if ($host.Version.Major -gt 5) {
-    $commandPrefix = '-Command'
+    $commandPrefix += '-Command'
 }
 
 function is_admin {


### PR DESCRIPTION
make it to inherit the execution policy from parent shell.
it's necessary when the execution policy was just set in process scope.